### PR TITLE
２回目の再生時に、最初からループ開始点まで飛んでしまう不具合を修正

### DIFF
--- a/AudioManager.cpp
+++ b/AudioManager.cpp
@@ -430,12 +430,12 @@ int AudioManager::playBgm(const std::string baseName, float fadeTime, bool loop,
             });
         }
     }
-
+    
+    _bgmFileName = baseName;
+	
     if (_bgmLoopList.count(_bgmFileName) > 0) {
         _bgmLoopList[_bgmFileName].isLoopInterval = false;
     }
-    
-    _bgmFileName = baseName;
     
     return _bgmId;
 }

--- a/AudioManager.cpp
+++ b/AudioManager.cpp
@@ -431,6 +431,10 @@ int AudioManager::playBgm(const std::string baseName, float fadeTime, bool loop,
         }
     }
 
+    if (_bgmLoopList.count(_bgmFileName) > 0) {
+        _bgmLoopList[_bgmFileName].isLoopInterval = false;
+    }
+    
     _bgmFileName = baseName;
     
     return _bgmId;


### PR DESCRIPTION
フラグ isLoopInterval が正しく初期化されていないので、表題のような現象が発生します。

とりあえず playBgm の最後にフラグを初期化するようにしたら、現象は解消しました。

（※最後の１行に無意味な差分が出てしまっていますが、無害です。すみません。）